### PR TITLE
Pcap stats output by time and copy stream metrics over to stream packets

### DIFF
--- a/capture_mpegts.sh
+++ b/capture_mpegts.sh
@@ -1,4 +1,15 @@
 #!/bin/bash
+#
+ERROR_LEVEL=error
+CPU_BIND=0
+MEM_BIND=0
 
 ## MPEGTS
-target/release/probe --no-progress --pcap-stats --immediate-mode --send-raw-stream
+RUST_LOG=$ERROR_LEVEL numactl --cpubind=$CPU_BIND --membind=$MEM_BIND \
+    target/release/probe \
+        --no-progress \
+        --pcap-stats \
+        --immediate-mode \
+        --show-tr101290 \
+        --send-raw-stream \
+        --send-json-header

--- a/capture_smpte2110.sh
+++ b/capture_smpte2110.sh
@@ -1,4 +1,14 @@
 #!/bin/bash
+#
+ERROR_LEVEL=error
+CPU_BIND=0
+MEM_BIND=0
 
 ## SMPTE2110
-target/release/probe --no-progress --pcap-stats --smpte2110 --send-raw-stream
+sudo RUST_LOG=$ERROR_LEVEL numactl --cpubind=$CPU_BIND --membind=$MEM_BIND \
+    target/release/probe \
+        --no-progress \
+        --pcap-stats \
+        --smpte2110 \
+        --send-raw-stream \
+        --send-json-header

--- a/monitor.sh
+++ b/monitor.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
 #
-target/release/monitor --no-progress --recv-raw-stream --send-to-kafka
+target/release/monitor \
+    --no-progress \
+    --recv-json-header \
+    --recv-raw-stream \
+    --output-file capture.ts \
+    --send-to-kafka

--- a/src/bin/probe.rs
+++ b/src/bin/probe.rs
@@ -1172,7 +1172,7 @@ async fn main() {
         let mut stream = cap.stream(BoxCodec).unwrap();
         let mut count = 0;
 
-        let stats_last_sent_ts = Instant::now();
+        let mut stats_last_sent_ts = Instant::now();
 
         while running_clone.load(Ordering::SeqCst) {
             while let Some(packet) = stream.next().await {
@@ -1183,8 +1183,10 @@ async fn main() {
                         ptx.send(packet_data).await.unwrap();
                         let current_ts = Instant::now();
                         if pcap_stats
-                            && current_ts.duration_since(stats_last_sent_ts).as_secs() >= 30
+                            && ((current_ts.duration_since(stats_last_sent_ts).as_secs() >= 30)
+                                || count == 1)
                         {
+                            stats_last_sent_ts = current_ts;
                             let stats = stream.capture_mut().stats().unwrap();
                             println!(
                                 "#{} Current stats: Received: {}, Dropped: {}, Interface Dropped: {}",

--- a/src/bin/probe.rs
+++ b/src/bin/probe.rs
@@ -1237,26 +1237,7 @@ async fn main() {
 
                 // Serialize metadata only if necessary
                 let metadata_msg = if send_json_header {
-                    let mut cloned_stream_data = stream_data.clone(); // Clone avoids copying the Arc<Vec<u8>>
-
-                    // get pid_map stream_data structure for this pid
-                    let pid_map = PID_MAP.lock().unwrap();
-                    let pid_stream_data = pid_map.get(&stream_data.pid).unwrap();
-                    cloned_stream_data.bitrate = pid_stream_data.bitrate;
-                    cloned_stream_data.bitrate_avg = pid_stream_data.bitrate_avg;
-                    cloned_stream_data.bitrate_max = pid_stream_data.bitrate_max;
-                    cloned_stream_data.bitrate_min = pid_stream_data.bitrate_min;
-                    cloned_stream_data.iat = pid_stream_data.iat;
-                    cloned_stream_data.iat_avg = pid_stream_data.iat_avg;
-                    cloned_stream_data.iat_max = pid_stream_data.iat_max;
-                    cloned_stream_data.iat_min = pid_stream_data.iat_min;
-                    cloned_stream_data.stream_type = pid_stream_data.stream_type.clone();
-                    cloned_stream_data.start_time = stream_data.start_time;
-                    cloned_stream_data.error_count = stream_data.error_count;
-                    cloned_stream_data.last_arrival_time = stream_data.last_arrival_time;
-                    cloned_stream_data.total_bits = stream_data.total_bits;
-                    cloned_stream_data.count = stream_data.count;
-
+                    let cloned_stream_data = stream_data.clone(); // Clone avoids copying the Arc<Vec<u8>>
                     let metadata = serde_json::to_string(&cloned_stream_data).unwrap();
 
                     Some(zmq::Message::from(metadata.as_bytes()))

--- a/src/bin/probe.rs
+++ b/src/bin/probe.rs
@@ -1179,7 +1179,7 @@ async fn main() {
                         count += 1;
                         let packet_data = Arc::new(data.to_vec());
                         ptx.send(packet_data).await.unwrap();
-                        if pcap_stats && count % 1000000 == 0 {
+                        if pcap_stats && count % 10_000 == 0 {
                             let stats = stream.capture_mut().stats().unwrap();
                             println!(
                                 "Current stats: Received: {}, Dropped: {}, Interface Dropped: {}",

--- a/src/bin/probe.rs
+++ b/src/bin/probe.rs
@@ -1216,7 +1216,7 @@ async fn main() {
 
         while let Some(mut batch) = rx.recv().await {
             for stream_data in batch.iter() {
-                info!("Batch processing {} packets", batch.len());
+                //debug!("Batch processing {} packets", batch.len());
                 let packet_slice = &stream_data.packet
                     [stream_data.packet_start..stream_data.packet_start + stream_data.packet_len];
 


### PR DESCRIPTION
Keep track of stream metrics in each packet we send to zmq.
Pcap stats output by time instead of packet.
numactl added to scripts.
improved scripts for capture cmds.